### PR TITLE
✨ Change Critical Plugs to Restore ON

### DIFF
--- a/office-deskplug.yaml
+++ b/office-deskplug.yaml
@@ -31,7 +31,7 @@ switch:
   - platform: gpio
     id: switch_id
     name: ${device_name}_switch
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     pin: GPIO15
     on_turn_on:
       - switch.turn_on: led_id
@@ -40,7 +40,7 @@ switch:
   - platform: gpio
     id: led_id
     internal: True
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     pin:
       number: GPIO02
       inverted: True

--- a/serverroom-plug.yaml
+++ b/serverroom-plug.yaml
@@ -31,7 +31,7 @@ switch:
   - platform: gpio
     id: switch_id
     name: ${device_name}_switch
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     pin: GPIO15
     on_turn_on:
       - switch.turn_on: led_id
@@ -40,7 +40,7 @@ switch:
   - platform: gpio
     id: led_id
     internal: True
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     pin:
       number: GPIO02
       inverted: True

--- a/test-plug.yaml
+++ b/test-plug.yaml
@@ -31,7 +31,7 @@ switch:
   - platform: gpio
     id: switch_id
     name: ${device_name}_switch
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     pin: GPIO15
     on_turn_on:
       - switch.turn_on: led_id
@@ -40,7 +40,7 @@ switch:
   - platform: gpio
     id: led_id
     internal: True
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     pin:
       number: GPIO02
       inverted: True


### PR DESCRIPTION
Change `restore_mode` to `RESTORE_DEFAULT_ON` on critical home plugs to avoid restart off and need to be turn on manually.